### PR TITLE
Add compatibility with post-AE versions of SKSE64

### DIFF
--- a/SkyrimRedirector/Main.c
+++ b/SkyrimRedirector/Main.c
@@ -7,6 +7,24 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+__declspec(dllexport) SKSEPluginVersionData SKSEPlugin_Version =
+{
+	PLUGIN_INFO_VERSION,
+
+	1,
+	"Skyrim Redirector",
+
+	"",
+	"https://github.com/Davipb/SkyrimRedirector",
+
+	// setting ourselves as "not using structures" hopefully exempts us from any version checking
+	VERSIONINDEPENDENTEX_NO_STRUCT_USE,
+	VERSIONINDEPENDENT_SIGNATURES,
+	{ 0 },
+	0,
+};
+
+// API for compatibility with older versions of SKSE64
 __declspec(dllexport) bool SKSEPlugin_Query(const SKSEInterface* skse, PluginInfo* info)
 {
 	SR_DEBUG("SKSE query received");

--- a/SkyrimRedirector/PluginAPI.h
+++ b/SkyrimRedirector/PluginAPI.h
@@ -19,12 +19,56 @@ typedef struct
 	void* QueryInterface;
 	void* GetPluginHandle;
 	void* GetReleaseIndex;
+	void* GetPluginInfo;
 
 } SKSEInterface;
 
 
 // The version of the PluginInfo struct when the program was compiled
 #define PLUGIN_INFO_VERSION 1
+
+// **********************************
+// flags for versionIndependence
+
+// set this if you are using a post-AE version of the Address Library
+#define VERSIONINDEPENDENT_ADDRESSLIBRARY_POSTAE 1
+
+// set this if you exclusively use signature matching to find your addresses and have NO HARDCODED ADDRESSES
+#define VERSIONINDEPENDENT_SIGNATURES 2
+
+// set this if you are using 1.6.629+ compatible structure layout (likely provided by CommonLib/SKSE)
+// this also marks you as incompatible with pre-1.6.629. see kVersionIndependentEx_NoStructUse if you have a
+// plugin that only does code patches and works across many versions
+#define VERSIONINDEPENDENT_STRUCTS_POST629 4
+
+// **********************************
+// flags for versionIndependenceEx
+
+// set this if your plugin either doesn't use any game structures or has put in extraordinary effort
+// to work with pre and post 1.6.629 structure layout
+#define VERSIONINDEPENDENTEX_NO_STRUCT_USE 1
+
+
+typedef struct
+{
+	uint32_t dataVersion;			// set to kVersion
+
+	uint32_t pluginVersion;			// version number of your plugin
+	char	name[256];				// null-terminated ASCII plugin name
+
+	char	author[256];			// null-terminated ASCII plugin author name (can be empty)
+	char	supportEmail[252];		// null-terminated ASCII support email address (can be empty)
+									// this is not for showing to users, it's in case I need to contact you about
+									// a compatibility problem with your plugin
+
+	// version compatibility
+	uint32_t versionIndependenceEx;	// set to one of the kVersionIndependentEx_ enums or zero
+	uint32_t versionIndependence;	// set to one of the kVersionIndependent_ enums or zero
+	uint32_t compatibleVersions[16];	// zero-terminated list of RUNTIME_VERSION_ defines your plugin is compatible with
+
+	uint32_t seVersionRequired;		// minimum version of the script extender required, compared against PACKED_SKSE_VERSION
+									// you probably should just set this to 0 unless you know what you are doing
+} SKSEPluginVersionData;
 
 typedef struct
 {


### PR DESCRIPTION
More current versions of SKSE64 have added static version declarations that all plugins must declare, along with the versions of Skyrim and SKSE64 that they support.

This adds the required structure, with enough bits saying "we don't care about versioning, we aren't using any data structures, just let us run"